### PR TITLE
Remove generator meta tag

### DIFF
--- a/themes/ghostwriter/layouts/partials/header.html
+++ b/themes/ghostwriter/layouts/partials/header.html
@@ -7,7 +7,7 @@
         <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
         <meta name="HandheldFriendly" content="True">
         <meta name="MobileOptimized" content="320">
-        {{ .Hugo.Generator }}
+        <meta name="generator" content="Hugo" />
         <meta name="robots" content="index,follow">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         {{ if .Site.Params.opengraph }}{{ partial "opengraph.html" . }}{{ end }}


### PR DESCRIPTION
`{{ .Hugo.Generator }}`は、

> **.Hugo.Generator** Meta tag for the version of Hugo that generated the site. Highly recommended to be included by default in all theme headers so we can start to track the usage and popularity of Hugo. Unlike other variables it outputs a **complete** HTML tag, e.g. `<meta name="generator" content="Hugo 0.15" />`
(https://gohugo.io/templates/variables/)

とのことなんですが、このせいでHugoのバージョンが違うと不要なdiffが発生します。

```diff
-        <meta name="generator" content="Hugo 0.19" />
+        <meta name="generator" content="Hugo 0.20.7" />
```
(https://github.com/HOXOMInc/blog/commit/92719669d2ca99287015ee59d3302ef5e9258ab6?diff=unified#diff-924e931145086e9a4ce21e57c51f0a0fL10)

ちゃんとやるならDockerとかを使ってバージョンを揃えるのが筋なんでしょうけど、とりあえずテンプレートのこの行を削っちゃうのがいい気がしました。

他の差分も混じっちゃってるんですけど、大きな問題にはならない予感がするのでこのまま投げます。